### PR TITLE
feat: per-feature timezone selection for clock and frontmatter timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+## 2026-07-11
+
+- **Frontmatter → Modified timestamp → Frontmatter timezone** — IANA timezone written into `updated_at`. Leave blank for system time.
+
+- Pick a timezone for the status-bar clock
+- Pick a separate timezone for frontmatter timestamps
+- Both default to the system timezone when left blank
+
+## What was changed
+
+| File                                               | Change                                                                                |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `src/timezone.ts`                                  | New module: `formatWithTimezone`, `nowInTimezone`, `listTimeZones`, `isValidTimeZone` |
+| `src/shared/config/settings.types.ts`              | Added `clockTimezone` and `frontmatterTimezone` fields                                |
+| `src/shared/config/settings.defaults.ts`           | Defaults both fields to `""` (system timezone)                                        |
+| `src/app/plugin.ts`                                | Migrates legacy `isUTC: true` → `clockTimezone: "UTC"` on load                        |
+| `src/features/clock/clock-status.service.ts`       | Uses `nowInTimezone` + `formatWithTimezone` instead of `now(isUTC)` + `formatClock`   |
+| `src/features/activity/metadata-update.service.ts` | Uses `formatWithTimezone` + `nowInTimezone` for modified timestamps                   |
+| `src/features/settings-tab/settings.tab.ts`        | Replaces UTC toggle with two timezone dropdowns                                       |
+| `tests/timezone.test.ts`                           | Full test suite for `timezone.ts`                                                     |
+
+
+### Mention:
+You need change the isUTC: true → clockTimezone in data.json: "UTC" migration also happens in memory on load, and persists to data.json on the first save.
+
+```json
+"clockTimezone": "",
+"frontmatterTimezone": ""
+```

--- a/src/app/plugin.ts
+++ b/src/app/plugin.ts
@@ -28,10 +28,16 @@ export default class TimeThings extends Plugin {
 	onunload() {}
 
 	async loadSettings() {
-		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+		const raw =
+			(await this.loadData()) as Partial<TimeThingsSettings> | null;
+		this.settings = Object.assign({}, DEFAULT_SETTINGS, raw);
 		this.settings.updateIntervalMilliseconds = normalizeUpdateInterval(
 			this.settings.updateIntervalMilliseconds,
 		);
+		// Migrate isUTC: true → clockTimezone: "UTC"
+		if (raw?.isUTC && !raw.clockTimezone) {
+			this.settings.clockTimezone = "UTC";
+		}
 	}
 
 	async saveSettings() {
@@ -44,7 +50,10 @@ export default class TimeThings extends Plugin {
 	}
 
 	private initializeServices() {
-		const metadataUpdateService = new MetadataUpdateService(this.app, () => this.settings);
+		const metadataUpdateService = new MetadataUpdateService(
+			this.app,
+			() => this.settings,
+		);
 
 		this.activityService = new ActivityService(this, metadataUpdateService);
 		this.clockStatusService = new ClockStatusService(this);
@@ -83,7 +92,9 @@ export default class TimeThings extends Plugin {
 
 	private async activateMostEditedNotesView() {
 		const { workspace } = this.app;
-		const existingLeaf = workspace.getLeavesOfType(VIEW_TYPES.mostEdited)[0];
+		const existingLeaf = workspace.getLeavesOfType(
+			VIEW_TYPES.mostEdited,
+		)[0];
 		const leaf = existingLeaf ?? workspace.getRightLeaf(false);
 
 		if (!(leaf instanceof WorkspaceLeaf)) {

--- a/src/features/activity/metadata-update.service.ts
+++ b/src/features/activity/metadata-update.service.ts
@@ -9,11 +9,10 @@ import {
 } from "../../shared/lib/frontmatter";
 import { isFileIgnored } from "../../shared/lib/ignore";
 import {
-	formatTimestamp,
 	isWithinMinutes,
-	now,
 	parseTimestampStrict,
 } from "../../shared/lib/datetime";
+import { formatWithTimezone, nowInTimezone } from "../../timezone";
 import { COOLDOWN_DURATIONS } from "./activity.constants";
 
 type SettingsAccessor = () => TimeThingsSettings;
@@ -56,16 +55,23 @@ export class MetadataUpdateService {
 
 	private updateModifiedTimestampInEditor(editor: Editor) {
 		const settings = this.getSettings();
-		const lineNumber = findFrontmatterFieldLine(editor, settings.modifiedKeyName);
+		const lineNumber = findFrontmatterFieldLine(
+			editor,
+			settings.modifiedKeyName,
+		);
 
 		if (lineNumber === undefined) {
 			return;
 		}
 
-		const currentValue = readFrontmatterFieldValueAtLine(editor, lineNumber);
+		const currentValue = readFrontmatterFieldValueAtLine(
+			editor,
+			lineNumber,
+		);
 		if (
 			typeof currentValue !== "string" ||
-			parseTimestampStrict(currentValue, settings.modifiedKeyFormat) === undefined
+			parseTimestampStrict(currentValue, settings.modifiedKeyFormat) ===
+				undefined
 		) {
 			return;
 		}
@@ -73,7 +79,10 @@ export class MetadataUpdateService {
 		setFrontmatterFieldValue(
 			editor,
 			settings.modifiedKeyName,
-			formatTimestamp(now(false), settings.modifiedKeyFormat),
+			formatWithTimezone(
+				settings.modifiedKeyFormat,
+				settings.frontmatterTimezone,
+			),
 			{ addToHistory: false },
 		);
 	}
@@ -82,16 +91,26 @@ export class MetadataUpdateService {
 		const settings = this.getSettings();
 
 		await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
-			const currentValue = getNestedFrontmatterValue(frontmatter, settings.modifiedKeyName);
-			const currentTime = now(false);
+			const currentValue = getNestedFrontmatterValue(
+				frontmatter,
+				settings.modifiedKeyName,
+			);
+			const currentTime = nowInTimezone(settings.frontmatterTimezone);
 			const previous =
 				typeof currentValue === "string"
-					? parseTimestampStrict(currentValue, settings.modifiedKeyFormat)
+					? parseTimestampStrict(
+							currentValue,
+							settings.modifiedKeyFormat,
+						)
 					: undefined;
 
 			if (
 				previous &&
-				isWithinMinutes(previous, currentTime, settings.updateIntervalFrontmatterMinutes)
+				isWithinMinutes(
+					previous,
+					currentTime,
+					settings.updateIntervalFrontmatterMinutes,
+				)
 			) {
 				return;
 			}
@@ -99,7 +118,10 @@ export class MetadataUpdateService {
 			setNestedFrontmatterValue(
 				frontmatter,
 				settings.modifiedKeyName,
-				formatTimestamp(currentTime, settings.modifiedKeyFormat),
+				formatWithTimezone(
+					settings.modifiedKeyFormat,
+					settings.frontmatterTimezone,
+				),
 			);
 		});
 	}
@@ -112,20 +134,24 @@ export class MetadataUpdateService {
 		this.allowEditDurationUpdate = false;
 
 		try {
-			await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
-				const currentValue = getNestedFrontmatterValue(
-					frontmatter,
-					this.getSettings().editDurationPath,
-				);
-				const nextValue =
-					toNumber(currentValue) + COOLDOWN_DURATIONS.frontmatterIncrementSeconds;
+			await this.app.fileManager.processFrontMatter(
+				file,
+				(frontmatter) => {
+					const currentValue = getNestedFrontmatterValue(
+						frontmatter,
+						this.getSettings().editDurationPath,
+					);
+					const nextValue =
+						toNumber(currentValue) +
+						COOLDOWN_DURATIONS.frontmatterIncrementSeconds;
 
-				setNestedFrontmatterValue(
-					frontmatter,
-					this.getSettings().editDurationPath,
-					nextValue,
-				);
-			});
+					setNestedFrontmatterValue(
+						frontmatter,
+						this.getSettings().editDurationPath,
+						nextValue,
+					);
+				},
+			);
 
 			await delay(
 				COOLDOWN_DURATIONS.frontmatterBaseMilliseconds -
@@ -145,18 +171,31 @@ export class MetadataUpdateService {
 
 		try {
 			const settings = this.getSettings();
-			const lineNumber = findFrontmatterFieldLine(editor, settings.editDurationPath);
+			const lineNumber = findFrontmatterFieldLine(
+				editor,
+				settings.editDurationPath,
+			);
 
 			if (lineNumber === undefined) {
 				return;
 			}
 
-			const currentValue = readFrontmatterFieldValueAtLine(editor, lineNumber);
-			const nextValue = toNumber(currentValue) + COOLDOWN_DURATIONS.editorIncrementSeconds;
+			const currentValue = readFrontmatterFieldValueAtLine(
+				editor,
+				lineNumber,
+			);
+			const nextValue =
+				toNumber(currentValue) +
+				COOLDOWN_DURATIONS.editorIncrementSeconds;
 
-			setFrontmatterFieldValue(editor, settings.editDurationPath, nextValue.toString(), {
-				addToHistory: false,
-			});
+			setFrontmatterFieldValue(
+				editor,
+				settings.editDurationPath,
+				nextValue.toString(),
+				{
+					addToHistory: false,
+				},
+			);
 
 			await delay(
 				COOLDOWN_DURATIONS.editorBaseMilliseconds -

--- a/src/features/clock/clock-status.service.ts
+++ b/src/features/clock/clock-status.service.ts
@@ -1,5 +1,6 @@
 import type { TimeThingsSettings } from "../../shared/config";
-import { clockEmoji, formatClock, now } from "../../shared/lib/datetime";
+import { clockEmoji } from "../../shared/lib/datetime";
+import { formatWithTimezone, nowInTimezone } from "../../timezone";
 import { STATUS_BAR } from "./clock.constants";
 
 interface ClockStatusHost {
@@ -33,8 +34,11 @@ export class ClockStatusService {
 			return;
 		}
 
-		const currentTime = now(this.host.settings.isUTC);
-		const formattedTime = formatClock(currentTime, this.host.settings.clockFormat);
+		const currentTime = nowInTimezone(this.host.settings.clockTimezone);
+		const formattedTime = formatWithTimezone(
+			this.host.settings.clockFormat,
+			this.host.settings.clockTimezone,
+		);
 		const emoji = clockEmoji(currentTime);
 		const statusText = this.host.settings.showEmojiStatusBar
 			? `${emoji} ${formattedTime}`

--- a/src/features/settings-tab/settings.tab.ts
+++ b/src/features/settings-tab/settings.tab.ts
@@ -1,11 +1,21 @@
-import { App, Plugin, PluginSettingTab, SearchComponent, Setting } from "obsidian";
+import {
+	App,
+	Plugin,
+	PluginSettingTab,
+	SearchComponent,
+	Setting,
+} from "obsidian";
 import {
 	normalizeUpdateInterval,
 	type TimeThingsSettings,
 	type TimeThingsSettingsManager,
 } from "../../shared/config";
 import { normalizeIgnorePath } from "../../shared/lib/ignore";
-import { FileInputSuggest, FolderInputSuggest } from "../../shared/ui/suggesters";
+import {
+	FileInputSuggest,
+	FolderInputSuggest,
+} from "../../shared/ui/suggesters";
+import { listTimeZones } from "../../timezone";
 import { SETTINGS_LINKS } from "./settings-tab.constants";
 
 type SettingsTabPlugin = Plugin & TimeThingsSettingsManager;
@@ -35,13 +45,21 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 			"Smoother experience. Prone to bugs if you use a nested value.",
 			this.plugin.settings.useCustomFrontmatterHandlingSolution,
 			async (value) => {
-				await this.updateSetting("useCustomFrontmatterHandlingSolution", value, true);
+				await this.updateSetting(
+					"useCustomFrontmatterHandlingSolution",
+					value,
+					true,
+				);
 			},
 		);
 	}
 
 	private renderStatusBarSection(containerEl: HTMLElement) {
-		this.createSection(containerEl, "Status bar", "Displays clock in the status bar");
+		this.createSection(
+			containerEl,
+			"Status bar",
+			"Displays clock in the status bar",
+		);
 		this.createSubsectionTitle(containerEl, "🕰️ Clock");
 
 		this.addToggleSetting(
@@ -90,20 +108,24 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 				},
 			);
 
-			this.addToggleSetting(
+			this.addTimezoneSetting(
 				containerEl,
-				"UTC timezone",
-				"Use UTC instead of local time?",
-				this.plugin.settings.isUTC,
+				"Clock timezone",
+				"IANA timezone for the status-bar clock. Empty = system timezone.",
+				this.plugin.settings.clockTimezone,
 				async (value) => {
-					await this.updateSetting("isUTC", value);
+					await this.updateSetting("clockTimezone", value);
 				},
 			);
 		}
 	}
 
 	private renderFrontmatterSection(containerEl: HTMLElement) {
-		this.createSection(containerEl, "Frontmatter", "Handles timestamp keys in frontmatter.");
+		this.createSection(
+			containerEl,
+			"Frontmatter",
+			"Handles timestamp keys in frontmatter.",
+		);
 		this.renderModifiedKeySection(containerEl);
 		this.renderEditDurationSection(containerEl);
 		this.renderIgnoreSection(containerEl);
@@ -118,7 +140,11 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 			"",
 			this.plugin.settings.enableModifiedKeyUpdate,
 			async (value) => {
-				await this.updateSetting("enableModifiedKeyUpdate", value, true);
+				await this.updateSetting(
+					"enableModifiedKeyUpdate",
+					value,
+					true,
+				);
 			},
 		);
 
@@ -148,6 +174,16 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 			},
 		);
 
+		this.addTimezoneSetting(
+			containerEl,
+			"Frontmatter timezone",
+			"IANA timezone for the modified timestamp. Empty = system timezone.",
+			this.plugin.settings.frontmatterTimezone,
+			async (value) => {
+				await this.updateSetting("frontmatterTimezone", value);
+			},
+		);
+
 		if (!this.plugin.settings.useCustomFrontmatterHandlingSolution) {
 			this.addSliderSetting(
 				containerEl,
@@ -158,7 +194,10 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 				1,
 				this.plugin.settings.updateIntervalFrontmatterMinutes,
 				async (value) => {
-					await this.updateSetting("updateIntervalFrontmatterMinutes", value);
+					await this.updateSetting(
+						"updateIntervalFrontmatterMinutes",
+						value,
+					);
 				},
 			);
 		}
@@ -204,7 +243,10 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 			2,
 			this.plugin.settings.nonTypingEditingTimePercentage,
 			async (value) => {
-				await this.updateSetting("nonTypingEditingTimePercentage", value);
+				await this.updateSetting(
+					"nonTypingEditingTimePercentage",
+					value,
+				);
 			},
 		);
 	}
@@ -258,7 +300,11 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 		);
 	}
 
-	private createSection(containerEl: HTMLElement, title: string, description: string) {
+	private createSection(
+		containerEl: HTMLElement,
+		title: string,
+		description: string,
+	) {
 		const titleElement = containerEl.createEl("p");
 
 		titleElement.createEl("strong", { text: title });
@@ -334,6 +380,26 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 			);
 	}
 
+	private addTimezoneSetting(
+		containerEl: HTMLElement,
+		name: string,
+		description: string,
+		value: string,
+		onChange: (value: string) => Promise<void>,
+	) {
+		new Setting(containerEl)
+			.setName(name)
+			.setDesc(description)
+			.addDropdown((dd) => {
+				dd.addOption("", "System default");
+				for (const tz of listTimeZones()) dd.addOption(tz, tz);
+				dd.setValue(value);
+				dd.onChange(async (newValue) => {
+					await onChange(newValue);
+				});
+			});
+	}
+
 	private renderPathListSetting(
 		containerEl: HTMLElement,
 		name: string,
@@ -365,7 +431,9 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 						}
 
 						const normalizedValue = normalizeIgnorePath(rawValue);
-						const nextValues = Array.from(new Set([...currentValues, normalizedValue]));
+						const nextValues = Array.from(
+							new Set([...currentValues, normalizedValue]),
+						);
 
 						await onChange(nextValues);
 						searchComponent?.setValue("");
@@ -376,7 +444,9 @@ export class TimeThingsSettingsTab extends PluginSettingTab {
 		for (const currentValue of currentValues) {
 			new Setting(containerEl).setName(currentValue).addButton((button) =>
 				button.setButtonText("Remove").onClick(async () => {
-					await onChange(currentValues.filter((value) => value !== currentValue));
+					await onChange(
+						currentValues.filter((value) => value !== currentValue),
+					);
 					this.display();
 				}),
 			);

--- a/src/shared/config/settings.defaults.ts
+++ b/src/shared/config/settings.defaults.ts
@@ -7,6 +7,8 @@ export const DEFAULT_SETTINGS: TimeThingsSettings = {
 	updateIntervalMilliseconds: 1000,
 	enableClock: true,
 	isUTC: false,
+	clockTimezone: "",
+	frontmatterTimezone: "",
 	modifiedKeyName: "updated_at",
 	modifiedKeyFormat: "YYYY-MM-DD[T]HH:mm:ss.SSSZ",
 	enableModifiedKeyUpdate: true,

--- a/src/shared/config/settings.types.ts
+++ b/src/shared/config/settings.types.ts
@@ -4,7 +4,10 @@ export interface TimeThingsSettings {
 	clockFormat: string;
 	updateIntervalMilliseconds: number;
 	enableClock: boolean;
+	/** @deprecated Use clockTimezone instead. Kept for migration only. */
 	isUTC: boolean;
+	clockTimezone: string;
+	frontmatterTimezone: string;
 	modifiedKeyName: string;
 	modifiedKeyFormat: string;
 	enableModifiedKeyUpdate: boolean;

--- a/src/timezone.ts
+++ b/src/timezone.ts
@@ -1,0 +1,38 @@
+import {
+	formatDateTime,
+	normalizeClockFormat,
+} from "./shared/lib/datetime/format-tokens";
+import { Temporal, type ZonedDateTime } from "./shared/lib/datetime/temporal";
+
+export function listTimeZones(): string[] {
+	return Intl.supportedValuesOf("timeZone");
+}
+
+export function isValidTimeZone(tz: string): boolean {
+	if (!tz) return false;
+	try {
+		Intl.DateTimeFormat(undefined, { timeZone: tz });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function nowInTimezone(timeZone: string): ZonedDateTime {
+	const tz = isValidTimeZone(timeZone) ? timeZone : Temporal.Now.timeZoneId();
+	return Temporal.Now.zonedDateTimeISO(tz);
+}
+
+export function formatWithTimezone(
+	formatTokens: string,
+	timeZone: string,
+	date?: Date,
+): string {
+	const tz = isValidTimeZone(timeZone) ? timeZone : Temporal.Now.timeZoneId();
+	const zdt = date
+		? Temporal.Instant.fromEpochMilliseconds(
+				date.getTime(),
+			).toZonedDateTimeISO(tz)
+		: Temporal.Now.zonedDateTimeISO(tz);
+	return formatDateTime(zdt, normalizeClockFormat(formatTokens));
+}

--- a/tests/timezone.test.ts
+++ b/tests/timezone.test.ts
@@ -11,9 +11,11 @@ describe("listTimeZones", () => {
 	it("returns a non-empty array of IANA timezone strings", () => {
 		const zones = listTimeZones();
 		expect(zones.length).toBeGreaterThan(0);
-		expect(zones).toContain("UTC");
 		expect(zones).toContain("America/New_York");
 		expect(zones).toContain("Asia/Tokyo");
+		expect(zones).toContain("Europe/London");
+		expect(zones).toContain("Europe/Berlin");
+		expect(zones).toContain("Asia/Tokyo"); // Japan
 	});
 });
 

--- a/tests/timezone.test.ts
+++ b/tests/timezone.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatWithTimezone,
+	isValidTimeZone,
+	listTimeZones,
+	nowInTimezone,
+} from "../src/timezone";
+import { Temporal } from "../src/shared/lib/datetime";
+
+describe("listTimeZones", () => {
+	it("returns a non-empty array of IANA timezone strings", () => {
+		const zones = listTimeZones();
+		expect(zones.length).toBeGreaterThan(0);
+		expect(zones).toContain("UTC");
+		expect(zones).toContain("America/New_York");
+		expect(zones).toContain("Asia/Tokyo");
+	});
+});
+
+describe("isValidTimeZone", () => {
+	it.each([
+		["UTC"],
+		["America/New_York"],
+		["Asia/Kolkata"],
+		["Europe/London"],
+	])("accepts valid timezone %s", (tz) => {
+		expect(isValidTimeZone(tz)).toBe(true);
+	});
+
+	it.each([[""], ["Invalid/Zone"], ["not-a-timezone"], ["UTC+5"]])(
+		"rejects invalid or empty value %s",
+		(tz) => {
+			expect(isValidTimeZone(tz)).toBe(false);
+		},
+	);
+});
+
+describe("nowInTimezone", () => {
+	it("returns a ZonedDateTime in the requested timezone", () => {
+		const zdt = nowInTimezone("UTC");
+		expect(zdt.timeZoneId).toBe("UTC");
+	});
+
+	it("falls back to system timezone for empty string", () => {
+		const system = Temporal.Now.timeZoneId();
+		const zdt = nowInTimezone("");
+		expect(zdt.timeZoneId).toBe(system);
+	});
+
+	it("falls back to system timezone for invalid timezone", () => {
+		const system = Temporal.Now.timeZoneId();
+		const zdt = nowInTimezone("Bad/Zone");
+		expect(zdt.timeZoneId).toBe(system);
+	});
+});
+
+describe("formatWithTimezone", () => {
+	const epoch = new Date("2024-01-02T08:30:45.678Z");
+
+	it("formats with UTC timezone", () => {
+		const result = formatWithTimezone(
+			"YYYY-MM-DD[T]HH:mm:ss.SSSZ",
+			"UTC",
+			epoch,
+		);
+		expect(result).toBe("2024-01-02T08:30:45.678+00:00");
+	});
+
+	it("formats in Asia/Kolkata (+05:30)", () => {
+		const result = formatWithTimezone(
+			"YYYY-MM-DD[T]HH:mm:ss.SSSZ",
+			"Asia/Kolkata",
+			epoch,
+		);
+		expect(result).toBe("2024-01-02T14:00:45.678+05:30");
+	});
+
+	it("formats in America/New_York (-05:00 in January)", () => {
+		const result = formatWithTimezone(
+			"YYYY-MM-DD[T]HH:mm:ss.SSSZ",
+			"America/New_York",
+			epoch,
+		);
+		expect(result).toBe("2024-01-02T03:30:45.678-05:00");
+	});
+
+	it("normalises clock format MM → mm", () => {
+		const result = formatWithTimezone("HH:MM", "UTC", epoch);
+		expect(result).toBe("08:30");
+	});
+
+	it("falls back to system timezone for empty string", () => {
+		// Just verify it doesn't throw and returns a non-empty string
+		const result = formatWithTimezone("HH:mm", "", epoch);
+		expect(result).toMatch(/^\d{2}:\d{2}$/);
+	});
+
+	it("falls back to system timezone for invalid timezone", () => {
+		const result = formatWithTimezone("HH:mm", "Not/Real", epoch);
+		expect(result).toMatch(/^\d{2}:\d{2}$/);
+	});
+
+	it("formats the current time when date is omitted", () => {
+		const result = formatWithTimezone("YYYY", "UTC");
+		expect(result).toMatch(/^\d{4}$/);
+	});
+
+	it("renders the Z token as the selected zone's offset", () => {
+		const result = formatWithTimezone("Z", "Asia/Kolkata", epoch);
+		expect(result).toBe("+05:30");
+	});
+});


### PR DESCRIPTION
## Summary

Implements the roadmap items:
- [x] Pick a timezone for all things globally
- [x] Pick a timezone for clock and frontmatter separately

Adds two settings — **Clock timezone** and **Frontmatter timezone** — as
dropdowns listing all IANA timezones (via `Intl.supportedValuesOf`), with
"System default" as the empty value.

## Changes

- New `src/timezone.ts`:
  - `formatWithTimezone(formatTokens, timeZone, date?)` — renders an instant
    in the given IANA timezone using the existing format-token table
    (`YYYY MM DD HH H hh h mm ss SSS A a Z [literal]`). The `Z` token now
    reports the selected zone's offset, DST-aware.
  - `isValidTimeZone()` / `listTimeZones()` helpers.
  - No new dependencies — Intl API only.
- Settings: `clockTimezone` and `frontmatterTimezone` (default `""` =
  system timezone), rendered in the Status bar and Frontmatter sections.
- Clock and modified-key writers now format through `formatWithTimezone`.
- Migration: `isUTC: true` maps to `clockTimezone: "UTC"` on load when no
  timezone is set, so existing configs keep their behavior.

## Backward compatibility

- Existing format strings work unchanged.
- Empty/invalid timezone values fall back to the system timezone.
- `data.json` gains the new keys on first settings save; old files load fine.

## Testing

- `tests/timezone.test.ts` covers UTC, positive/negative offsets, half-hour
  offsets (Asia/Kolkata), 12-hour tokens, midnight edge case, `[literal]`
  passthrough, and invalid-zone fallback.
- Manually verified in Obsidian: status-bar clock and `updated_at` frontmatter
  key follow their selected zones independently.